### PR TITLE
fix: remove debug console.log statements from main.ts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -108,12 +108,10 @@ const getAccessToken = async (
 
 function removeMergeNotifs() {
 	//Add a setting for it and check if its enabled here
-	console.log("Calling this!");
 	const notices = document.querySelectorAll(".notice");
 	notices.forEach((notice) => {
 		if (notice.textContent?.includes("has been modified externally")) {
 			notice.remove();
-			console.log("A merge notice has been removed!");
 			return;
 		}
 	});


### PR DESCRIPTION
Removed two debug console.log statements from main.ts that were left in production code. These appear to be leftover debugging statements from the removeMergeNotifs function. — Sent via @AmSach bot